### PR TITLE
Auto-register dependencies and permission classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+node_modules


### PR DESCRIPTION
Added changes to the CMS service provider that will automatically register `Illuminate/Html` and related Facades. Also registers Bootleg/Cms/Permissions class, rather than requiring user to edit `app/Http/Kernel.php` manually.

Finally, added `node_modules` to .gitignore file.